### PR TITLE
SPUD Serializer ReadStream 'close' event handler

### DIFF
--- a/lib/transcoder.js
+++ b/lib/transcoder.js
@@ -113,8 +113,9 @@ exports = module.exports = {
         var src = writer.createReadStream();
         src.on('data', writeStream.write.bind(writeStream));
         src.on('error', callback);
-        src.on('close', function () {
-            callback(null, writeStream.data.toString('utf8'));
+        src.on('end', function () {
+        	writeStream.end();
+            callback(null, writeStream['_data'].toString('utf8'));
         });
 
         // Stream the serialized data to the file write stream


### PR DESCRIPTION
The 'close' event set on the readstream was not firing, so I switched it to the end event.  I also corrected its callback method to end the writeStream and access the correct property name ( writeStream['_data'] instead of writeStream['data'], which was undefined ).

The mocha unit tests all passed after my change, so I do not think the issue was specific to the custom serializer I am using in my project.
