### PR TITLE
Customizable State-Based Serialization/Deserialization

### DIFF
--- a/lib/serializer/properties/reader.js
+++ b/lib/serializer/properties/reader.js
@@ -25,8 +25,29 @@ var util = require('util'),
 	codePointAt = require('string.fromcodepoint'),
 	AbstractReader = require('../abstractReader');
 
-function PropertyReader() {
+function default_proccessKeyValue( key, value, state ) {
+	return { kvp: { key: key, value: value }, state: state }
+}
+function default_processComment( comment, state ) {
+	return { kvp: null, state: state }
+}
+function default_getStartState() {
+	return {};
+}
+
+function PropertyReader(options) {
 	PropertyReader.super_.call(this);
+
+	this.options = options || {};
+	if ( ! this.options.processKeyValue ) {
+		this.options.processKeyValue = default_proccessKeyValue;
+	}
+	if ( ! this.options.processComment ) {
+		this.options.processComment = default_processComment;
+	}
+	if ( ! this.options.getStartState ) {
+		this.options.getStartState = default_getStartState;
+	}
 }
 
 util.inherits(PropertyReader, AbstractReader);
@@ -36,8 +57,71 @@ function  getEscapedChar(match) {
 	return String.fromCodePoint(parseInt(match, 16));
 }
 
+function addKvp( kvp, data ) {
+	if ( ! kvp ) {
+		return;
+	}
+	if ( ! kvp.key ) {
+		throw new Error("Key is missing.  Cannot add key/value pair.");
+	}
+	var key = kvp.key;
+	var value = kvp.value;
+
+	if (key.indexOf('\\u') !== -1) {
+		//ES6 format: \u{xxxxxx}
+		if (key.indexOf('\\u{') !== -1) {
+			key = key.replace(/(\\u\{[A-Z0-9]{1,6}})/gi, getEscapedChar);
+		} else {
+			key = key.replace(/(\\u[A-Z0-9]{4})/gi, getEscapedChar);
+		}
+	}
+
+	var tail = data;
+	key.split(/\./).forEach(function (prop, index, arr) {
+
+		// Sanitize key
+		prop = prop.replace(/\s/g, '');
+		// Change to allow most any chars for name and map key
+		var arrMap = prop.match(/^([^\[]+)\[(.*)\]$/);
+		if ( Array.isArray(arrMap) && arrMap.length > 1 ) {
+			var arrKey = arrMap[1];
+			if ( arrMap[2] !== '' ) {
+				// If previous value is present for this key, use it, otherwise new object
+				arrMap[2].split(/\]\[/).forEach(function (arrProp, arrIndex, subArr) {
+					// Iterate over the property keys
+					if ( arrProp.match(/^[0-9]+$/) ) {
+						if ( arrIndex === 0 ) {
+							tail = tail[arrKey] = (typeof tail[arrKey] !== 'undefined' && typeof tail[arrKey] === 'object') ? tail[arrKey] : [];
+						}
+						// Assign the value if it's the last key in the set
+						tail[arrProp] = ( arrIndex === subArr.length - 1 ) ? value : tail[arrProp] || [];
+					} else {
+						if ( arrIndex === 0 ) {
+							tail = tail[arrKey] = (typeof tail[arrKey] !== 'undefined' && typeof tail[arrKey] === 'object') ? tail[arrKey] : {};
+						}
+						// Assign the value if it's the last key in the set
+						tail[arrProp] = ( arrIndex === subArr.length - 1 ) ? value : tail[arrProp] || {};
+					}
+					tail = tail[arrProp];
+				});
+			}
+		} else if (index === arr.length - 1) {
+			// On the final property in the namespace
+			// Property wasn't yet defined, so just set a value
+			tail[prop] = value;
+		} else {
+			// Continue through the namespace. If a property
+			// was defined in a previous iteration, use it,
+			// otherwise, create an empty object and move on.
+			tail = tail[prop] = (tail[prop] || {});
+		}
+	});
+}
+
 PropertyReader.prototype._doDeserialize = function(data, callback) {
 	var result = {};
+
+	var state = this.options.getStartState();
 
 	data.split(/\r?\n/).forEach(function (line) {
 		var kvp = line.match(/^(?!\s*#)([^=]+)=(.+)$/),
@@ -47,57 +131,26 @@ PropertyReader.prototype._doDeserialize = function(data, callback) {
 		if (Array.isArray(kvp) && kvp.length > 1) {
 			key = kvp[1].trim();
 			value = kvp[2];
-			if (key.indexOf('\\u') !== -1) {
-				//ES6 format: \u{xxxxxx}
-				if (key.indexOf('\\u{') !== -1) {
-					key = key.replace(/(\\u\{[A-Z0-9]{1,6}})/gi, getEscapedChar);
-				} else {
-					key = key.replace(/(\\u[A-Z0-9]{4})/gi, getEscapedChar);
-				}
-			}
+			
+			var processed = this.options.processKeyValue( key, value, state );
+			state = processed.state;
+			addKvp( processed.kvp, result );
 
-			var tail = result;
-			key.split(/\./).forEach(function (prop, index, arr) {
-
-				// Sanitize key
-				prop = prop.replace(/\s/g, '');
-				// Change to allow most any chars for name and map key
-				var arrMap = prop.match(/^([^\[]+)\[(.*)\]$/);
-				if ( Array.isArray(arrMap) && arrMap.length > 1 ) {
-					var arrKey = arrMap[1];
-					if ( arrMap[2] !== '' ) {
-						// If previous value is present for this key, use it, otherwise new object
-						arrMap[2].split(/\]\[/).forEach(function (arrProp, arrIndex, subArr) {
-							// Iterate over the property keys
-							if ( arrProp.match(/^[0-9]+$/) ) {
-								if ( arrIndex === 0 ) {
-									tail = tail[arrKey] = (typeof tail[arrKey] !== 'undefined' && typeof tail[arrKey] === 'object') ? tail[arrKey] : [];
-								}
-								// Assign the value if it's the last key in the set
-								tail[arrProp] = ( arrIndex === subArr.length - 1 ) ? value : tail[arrProp] || [];
-							} else {
-								if ( arrIndex === 0 ) {
-									tail = tail[arrKey] = (typeof tail[arrKey] !== 'undefined' && typeof tail[arrKey] === 'object') ? tail[arrKey] : {};
-								}
-								// Assign the value if it's the last key in the set
-								tail[arrProp] = ( arrIndex === subArr.length - 1 ) ? value : tail[arrProp] || {};
-							}
-							tail = tail[arrProp];
-						});
-					}
-				} else if (index === arr.length - 1) {
-					// On the final property in the namespace
-					// Property wasn't yet defined, so just set a value
-					tail[prop] = value;
-				} else {
-					// Continue through the namespace. If a property
-					// was defined in a previous iteration, use it,
-					// otherwise, create an empty object and move on.
-					tail = tail[prop] = (tail[prop] || {});
-				}
-			});
+			return;
 		}
-	});
+
+		var commentMatch = line.match(/^\s*#(.*)$/);
+
+		if (Array.isArray(commentMatch) && commentMatch.length > 1) {
+			var comment = commentMatch[1];
+			var processed = this.options.processComment( comment, state );
+			state = processed.state;
+			addKvp( processed.kvp, result );
+
+			return;
+		}
+
+	}.bind(this));
 	callback(null, result);
 };
 

--- a/lib/serializer/properties/reader.js
+++ b/lib/serializer/properties/reader.js
@@ -26,10 +26,10 @@ var util = require('util'),
 	AbstractReader = require('../abstractReader');
 
 function default_proccessKeyValue( key, value, state ) {
-	return { kvp: { key: key, value: value }, state: state }
+	return { kvp: { key: key, value: value }, state: state };
 }
 function default_processComment( comment, state ) {
-	return { kvp: null, state: state }
+	return { kvp: null, state: state };
 }
 function default_getStartState() {
 	return {};
@@ -143,9 +143,9 @@ PropertyReader.prototype._doDeserialize = function(data, callback) {
 
 		if (Array.isArray(commentMatch) && commentMatch.length > 1) {
 			var comment = commentMatch[1];
-			var processed = this.options.processComment( comment, state );
-			state = processed.state;
-			addKvp( processed.kvp, result );
+			var processedCom = this.options.processComment( comment, state );
+			state = processedCom.state;
+			addKvp( processedCom.kvp, result );
 
 			return;
 		}

--- a/lib/serializer/properties/writer.js
+++ b/lib/serializer/properties/writer.js
@@ -25,67 +25,101 @@ var os = require('os'),
 	stream = require('stream'),
 	AbstractWriter = require('../abstractWriter');
 
-function PropertyWriter() {
+function default_proccessKeyValue( namespace, item, state ) {
+	return { kvp: { key: namespace, value: item }, state: state }
+}
+function default_getStartState() {
+	return { "__prepend__": null, "__append__": null };
+}
+
+function PropertyWriter(options) {
 	PropertyWriter.super_.call(this);
+
+	this.options = options || {};
+	if ( ! this.options.processKeyValue ) {
+		this.options.processKeyValue = default_proccessKeyValue;
+	}
+	if ( ! this.options.getStartState ) {
+		this.options.getStartState = default_getStartState;
+	}
 }
 
 util.inherits(PropertyWriter, AbstractWriter);
 
 PropertyWriter.prototype._doCreateReadStream = function(data) {
-	return new ReadStream(data);
+	return new ReadStream(data, this.options);
 };
 
 
-function ReadStream(data) {
+function ReadStream(data, options) {
 	ReadStream.super_.call(this);
 	this._data = data;
+	this.options = options;
 }
 
 util.inherits(ReadStream, stream.Readable);
 
 ReadStream.prototype._read = function (size) {
-	this._process(null, this._data);
+	this._process( null, this._data, this.options.getStartState() );
 	this.push(null);
 };
 
-ReadStream.prototype._process = function (namespace, data) {
+ReadStream.prototype._process = function (namespace, data, state) {
 
 	// TODO: Some more work in this direction to make it
 	// super fast, if necessary.
+
+	var processed = this.options.processKeyValue( namespace, data, state );
+	state = processed.state;
+	namespace = processed.kvp.key;
+	data = processed.kvp.value;
 
 	switch (typeof data) {
 		case 'object':
 			if (Array.isArray(data)) {
 				data.forEach(function (item) {
-					this._process(namespace, item);
+					state = this._process(namespace, item, state);
 				}.bind(this));
 			} else if (data === null) {
-				this._process(namespace, String(data));
+				state = this._process(namespace, String(data), state);
 				break;
 			} else {
 				Object.keys(data).forEach(function (key) {
 					var name = namespace ? namespace + '.' + key : key;
-					this._process(name, data[key]);
+					state = this._process(name, data[key], state);
 				}.bind(this));
 			}
 			break;
 
 		case 'number':
-			this._process(namespace, Number.isFinite(data) ? String(data) : '');
+			state = this._process(namespace, Number.isFinite(data) ? String(data) : '', state);
 			break;
 
 		case 'boolean':
-			this._process(namespace, String(data));
+			state = this._process(namespace, String(data), state);
 			break;
 
 		case 'string':
+			if ( state["__prepend__"] ) {
+				this.push( state["__prepend__"] + os.EOL );
+			}
+			state["__prepend__"] = null;
+
 			var value = [namespace, '=', data, os.EOL].join('');
 			this.push(value);
+
+			if ( state["__append__"] ) {
+				this.push( state["__append__"] + os.EOL );
+			}
+			state["__append__"] = null;
+
 			break;
 
 		default:
 			console.warn('Unserializable value:', data);
 	}
+
+	return state;
 };
 
 module.exports = PropertyWriter;

--- a/lib/serializer/properties/writer.js
+++ b/lib/serializer/properties/writer.js
@@ -26,7 +26,7 @@ var os = require('os'),
 	AbstractWriter = require('../abstractWriter');
 
 function default_proccessKeyValue( namespace, item, state ) {
-	return { kvp: { key: namespace, value: item }, state: state }
+	return { kvp: { key: namespace, value: item }, state: state };
 }
 function default_getStartState() {
 	return { "__prepend__": null, "__append__": null };
@@ -100,18 +100,18 @@ ReadStream.prototype._process = function (namespace, data, state) {
 			break;
 
 		case 'string':
-			if ( state["__prepend__"] ) {
-				this.push( state["__prepend__"] + os.EOL );
+			if ( state.__prepend__ ) {
+				this.push( state.__prepend__ + os.EOL );
 			}
-			state["__prepend__"] = null;
+			state.__prepend__ = null;
 
 			var value = [namespace, '=', data, os.EOL].join('');
 			this.push(value);
 
-			if ( state["__append__"] ) {
-				this.push( state["__append__"] + os.EOL );
+			if ( state.__append__ ) {
+				this.push( state.__append__ + os.EOL );
 			}
-			state["__append__"] = null;
+			state.__append__ = null;
 
 			break;
 

--- a/lib/serializer/serializerFactory.js
+++ b/lib/serializer/serializerFactory.js
@@ -34,9 +34,9 @@ exports = module.exports = {
 		return clazz;
 	},
 
-	buildDeserializer: function (type) {
+	buildDeserializer: function (type, options) {
 		var Clazz = this._getLibForType(type).Reader;
-		return new Clazz();
+		return new Clazz(options);
 	},
 
 	buildSerializer: function (type) {

--- a/lib/serializer/serializerFactory.js
+++ b/lib/serializer/serializerFactory.js
@@ -39,9 +39,9 @@ exports = module.exports = {
 		return new Clazz(options);
 	},
 
-	buildSerializer: function (type) {
+	buildSerializer: function (type, options) {
 		var Clazz = this._getLibForType(type).Writer;
-		return new Clazz();
+		return new Clazz(options);
 	},
 
 	register: function (type, serializer) {

--- a/lib/transcoder.js
+++ b/lib/transcoder.js
@@ -70,6 +70,7 @@ module.exports = {
 	 * Convert the source data to a JavaScript Object
 	 * @param  {Object}   source	 Can be a file path, Buffer, or Stream
 	 * @param  {String}   sourceType The type of input to be deserialized, e.g. 'json', 'properties'
+	 * @param  {Object}   options    An optional object which may contain functions to modify parsing behavior
 	 * @param  {Function} callback   The callback to invoke with the serialized data or errors.
 	 */
 	deserialize: function deserialize(source, sourceType, options, callback) {
@@ -121,11 +122,16 @@ module.exports = {
 	 * @param  {Object}   source		the source object
 	 * @param  {String}   targetType	the resulting serialization type, e.g. 'json', 'properties'
 	 * @param  {Stream}   [writeStream] Optional. The stream to which the serialized output should be written.
+	 * @param  {Object}   options       An optional object which may contain functions to modify serialization behavior
 	 * @param  {Function} [callback]	Optional. The callback to invoke with the serialized data or errors.
 	 */
-	serialize: function (source, targetType, writeStream, callback) {
+	serialize: function (source, targetType, writeStream, options, callback) {
+		if ( typeof options === "function" ) {
+			callback = options;
+			options = {};
+		}
 
-		var writer = SerializerFactory.buildSerializer(targetType);
+		var writer = SerializerFactory.buildSerializer(targetType, options);
 		writer.data = source;
 		var src = writer.createReadStream();
 

--- a/lib/transcoder.js
+++ b/lib/transcoder.js
@@ -72,7 +72,11 @@ module.exports = {
 	 * @param  {String}   sourceType The type of input to be deserialized, e.g. 'json', 'properties'
 	 * @param  {Function} callback   The callback to invoke with the serialized data or errors.
 	 */
-	deserialize: function deserialize(source, sourceType, callback) {
+	deserialize: function deserialize(source, sourceType, options, callback) {
+		if ( typeof options === "function" ) {
+			callback = options;
+			options = {};
+		}
 		if (Buffer.isBuffer(source)) {
 			var temp = source;
 			source = new stream.PassThrough();
@@ -81,7 +85,7 @@ module.exports = {
 			source = fs.createReadStream(source);
 		}
 
-		var deserializer = SerializerFactory.buildDeserializer(sourceType);
+		var deserializer = SerializerFactory.buildDeserializer(sourceType, options);
 
 		source.on('error', callback);
 		source.on('end', function () {

--- a/test/properties.js
+++ b/test/properties.js
@@ -253,7 +253,7 @@ test('PropertyReader should register translate/no translate commands by overridi
 
 	var options = {
 		processKeyValue: function( key, value, state ) {
-			return { kvp: { key: key, value: { value: value, translate: state.translating } }, state: state }
+			return { kvp: { key: key, value: { value: value, translate: state.translating } }, state: state };
 		},
 		processComment: function( comment, state ) {
 			var trans = comment.match(/^\s*translate\s*:\s*((?:true)|(?:false))\s*$/i);
@@ -262,7 +262,7 @@ test('PropertyReader should register translate/no translate commands by overridi
 				var newState = { translating: willTranslate };
 				return { kvp: null, state: newState };
 			}
-			return { kvp: null, state: state }
+			return { kvp: null, state: state };
 		},
 		getStartState: function() {
 			return { translating: true };
@@ -274,38 +274,38 @@ test('PropertyReader should register translate/no translate commands by overridi
 		t.notOk(err);
 		t.ok(data);
 
-		t.equal(data.keyValueTest1['value'], 'My Value 1');
-		t.equal(data.keyValueTest1['translate'], true);
-		t.equal(data.keyValueTest2['value'], ' My Value 2');
-		t.equal(data.keyValueTest2['translate'], true);
-		t.equal(data.keyValueTest3['value'], 'My Value 3 ');
-		t.equal(data.keyValueTest3['translate'], true);
-		t.equal(data.keyValueTest4['value'], ' My Value 4 ');
-		t.equal(data.keyValueTest4['translate'], true);
-		t.equal(data.aPage.overWriteTest['value'], 'New value!');
-		t.equal(data.aPage.overWriteTest['translate'], false);
-		t.equal(data[42]['value'], 'universe');
-		t.equal(data[42]['translate'], true);
-		t.equal(data.a_b['value'], 'abc');
-		t.equal(data.a_b['translate'], true);
-		t.equal(data['@@']['value'], 'at');
-		t.equal(data['@@']['translate'], false);
-		t.equal(data['!#']['value'], 'bangpound');
-		t.equal(data['!#']['translate'], false);
-		t.equal(data['"\'']['value'], 'quotes');
-		t.equal(data['"\'']['translate'], false);
-		t.equal(data["espa\u00F1ol"]['value'], 'spanish');
-		t.equal(data["espa\u00F1ol"]['translate'], false);
-		t.equal(data["\u2603escapeA"]['value'], 'snowmanEscapeA');
-		t.equal(data["\u2603escapeA"]['translate'], false);
-		t.equal(data["\u2708"]['value'], 'airplane');
-		t.equal(data["\u2708"]['translate'], true);
-		t.equal(data["\u2603"]['value'], 'snowman');
-		t.equal(data["\u2603"]['translate'], true);
-		t.equal(data[String.fromCodePoint(128169)]['value'], 'pileOfPoo');
-		t.equal(data[String.fromCodePoint(128169)]['translate'], true);
-		t.equal(data[String.fromCodePoint(128169)+ "\u2708"]['value'], 'pooOnAPlane');
-		t.equal(data[String.fromCodePoint(128169)+ "\u2708"]['translate'], true);
+		t.equal(data.keyValueTest1.value, 'My Value 1');
+		t.equal(data.keyValueTest1.translate, true);
+		t.equal(data.keyValueTest2.value, ' My Value 2');
+		t.equal(data.keyValueTest2.translate, true);
+		t.equal(data.keyValueTest3.value, 'My Value 3 ');
+		t.equal(data.keyValueTest3.translate, true);
+		t.equal(data.keyValueTest4.value, ' My Value 4 ');
+		t.equal(data.keyValueTest4.translate, true);
+		t.equal(data.aPage.overWriteTest.value, 'New value!');
+		t.equal(data.aPage.overWriteTest.translate, false);
+		t.equal(data[42].value, 'universe');
+		t.equal(data[42].translate, true);
+		t.equal(data.a_b.value, 'abc');
+		t.equal(data.a_b.translate, true);
+		t.equal(data['@@'].value, 'at');
+		t.equal(data['@@'].translate, false);
+		t.equal(data['!#'].value, 'bangpound');
+		t.equal(data['!#'].translate, false);
+		t.equal(data['"\''].value, 'quotes');
+		t.equal(data['"\''].translate, false);
+		t.equal(data["espa\u00F1ol"].value, 'spanish');
+		t.equal(data["espa\u00F1ol"].translate, false);
+		t.equal(data["\u2603escapeA"].value, 'snowmanEscapeA');
+		t.equal(data["\u2603escapeA"].translate, false);
+		t.equal(data["\u2708"].value, 'airplane');
+		t.equal(data["\u2708"].translate, true);
+		t.equal(data["\u2603"].value, 'snowman');
+		t.equal(data["\u2603"].translate, true);
+		t.equal(data[String.fromCodePoint(128169)].value, 'pileOfPoo');
+		t.equal(data[String.fromCodePoint(128169)].translate, true);
+		t.equal(data[String.fromCodePoint(128169)+ "\u2708"].value, 'pooOnAPlane');
+		t.equal(data[String.fromCodePoint(128169)+ "\u2708"].translate, true);
 
 
 		t.end();
@@ -326,12 +326,12 @@ test('PropertyWriter should log translate/no translate commands by overriding ho
 		processKeyValue: function( namespace, item, state ) {
 			if ( typeof item === "object" && item.hasOwnProperty('translate') && isShallow( item ) ) {
 				var newState = state;
-				if ( item['translate'] !== state.translating ) {
-					newState = { "translating": item['translate'], "__prepend__": "# translate: " + item['translate'].toString() };
+				if ( item.translate !== state.translating ) {
+					newState = { "translating": item.translate, "__prepend__": "# translate: " + item.translate.toString() };
 				}
-				return { kvp: { key: namespace, value: item['value'] }, state: newState };
+				return { kvp: { key: namespace, value: item.value }, state: newState };
 			}
-			return { kvp: { key: namespace, value: item }, state: state }
+			return { kvp: { key: namespace, value: item }, state: state };
 		},
 		getStartState: function() {
 			return { translating: true };

--- a/test/properties/locales/en-US/commandComments.properties
+++ b/test/properties/locales/en-US/commandComments.properties
@@ -1,0 +1,27 @@
+keyValueTest1=My Value 1
+keyValueTest2 = My Value 2
+keyValueTest3=My Value 3 
+keyValueTest4 = My Value 4 
+42=universe
+a_b=abc
+
+# translate: false
+aPage.overWriteTest=Blarg
+aPage.overWriteTest=New value!
+
+address.state.az.key=AZ
+address.state.az.value=Arizona
+address.state.ca.key=CA
+address.state.ca.value=California
+
+# Test funky characters in keys
+@@=at
+!#=bangpound
+"'=quotes
+español=spanish
+\u2603escape\u0041=snowmanEscapeA
+# traNslate  : trUe
+\u2708=airplane
+\u{1F4A9}=pileOfPoo
+\u{1F4A9}\u{2708}=pooOnAPlane
+☃=snowman


### PR DESCRIPTION
allows users to define functions in an 'options' object passed to the SerializerFactory which allows the user to customize parsing/serialization behavior.

An example application would be for the L10N team to add comment-embedded commands (such as "# translate: false" marking a block of key/value pairs which shouldn't be translated).  An example implementation of this can be found in the two test suites added to test/properties.js

Documentation for the "options" object has not yet been added; this pull request is intended to show the idea and receive feedback.  If we decide to pursue this direction, I will work on adding documentation.
